### PR TITLE
This PR refactors and extends core utilities, unifies include directives across modules, renames and formalizes SMS and network callback APIs, and tweaks the HTTP client formatting.

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -1,0 +1,175 @@
+# A9G GPS Tracker - Developer Guide
+
+This guide provides an overview of the firmware architecture, focusing on the main application files, functional blocks, and their interactions.
+
+---
+
+## 1. Application File Overview
+
+| File                        | Description |
+|-----------------------------|-------------|
+| **system.h / system.c**     | System initialization, status flags, macros, and main event loop. |
+| **gps_tracker.h / .c**      | GPS hardware control, data parsing, tracker task, and location reporting. |
+| **network.h / .c**          | GSM network management, cell info, LBS (cell-based location), and watchdog. |
+| **config_store.h / .c**     | Persistent configuration storage and access. |
+| **config_commands.h / .c**  | UART command parsing, command table, and command handlers. |
+| **http.h / .c**             | HTTP/HTTPS client for server communication. |
+| **sms_service.h / .c**      | SMS command processing and location reporting via SMS. |
+| **debug.h / .c**            | Logging utilities with tags and timestamps. |
+| **utils.h / .c**            | Utility functions (string, time, etc). |
+| **led_handler.h / .c**      | (If present) LED status indicator logic. |
+
+---
+
+## 2. Main Functional Blocks
+
+### 2.1 System Initialization
+- Initializes hardware and software modules.
+- Sets up main tasks and event handlers.
+- Maintains system status flags (e.g., GSM active, GPS on).
+
+### 2.2 GPS Tracker
+- Controls GPS hardware and parses NMEA data.
+- Maintains a `GpsTrackerData_t` struct with the latest location, speed, bearing, altitude, and accuracy.
+- Periodically sends location data to the server if network is available.
+
+### 2.3 Network Management
+- Handles GSM registration, attach/activate, and network watchdog.
+- Requests and stores cell info for LBS (Location Based Service) fallback.
+- Provides blocking LBS location retrieval for UART commands.
+
+### 2.4 Configuration Management
+- Loads and saves configuration parameters (APN, server, device name, etc) to flash.
+- Provides get/set access for other modules and command handlers.
+
+### 2.5 UART Command Interface
+- Receives and parses commands from UART.
+- Uses a command table (`uart_cmd_table`) with command strings, handler pointers, and help text.
+- Sorts commands by length for unambiguous matching.
+- Routes commands to handler functions (e.g., `HandleSetCommand`, `HandleLbsCommand`).
+
+### 2.6 HTTP Client
+- Sends location and status data to a remote server using HTTP or HTTPS.
+- Handles SSL configuration if required.
+
+### 2.7 SMS Service
+- Processes incoming SMS commands.
+- Sends location or status via SMS on request.
+
+### 2.8 Logging
+- Provides tagged, timestamped logs for debugging and monitoring.
+- Output can be sent to UART or stored as needed.
+
+---
+
+## 3. Block Interactions & Data Flow
+
+```
+┌──────────────┐      ┌──────────────┐      ┌──────────────┐
+│  UART/CLI    │<---->│ config_cmds  │<---->│ config_store │
+└──────────────┘      └──────────────┘      └──────────────┘
+      │                        │
+      ▼                        ▼
+┌──────────────┐      ┌──────────────┐
+│ gps_tracker  │<---->│   network    │
+└──────────────┘      └──────────────┘
+      │                        │
+      ▼                        ▼
+┌──────────────┐      ┌──────────────┐
+│   http       │      │ sms_service  │
+└──────────────┘      └──────────────┘
+```
+
+- **UART/CLI**: User interface for configuration and control.
+- **config_cmds**: Parses commands, updates config, triggers actions.
+- **config_store**: Loads/saves persistent settings.
+- **gps_tracker**: Collects and processes GPS data.
+- **network**: Manages GSM, cell info, and LBS.
+- **http**: Sends data to server.
+- **sms_service**: Handles SMS-based commands and notifications.
+
+---
+
+## 4. UART Command Handling (Internal Details)
+
+### Data Structures
+- **uart_cmd_entry**: Structure holding command string, length, handler pointer, syntax, and help text.
+- **uart_cmd_table**: Array of all supported commands.
+- **uart_cmd_sorted_idx**: Array of indices, sorted by command length (longest first) for unambiguous matching.
+
+**Why is a sorted index used?**
+
+The sorted index (`uart_cmd_sorted_idx`) ensures that longer (more specific) commands are matched before shorter ones. This prevents ambiguous matches when one command is a prefix of another (for example, `net` and `net activate`). By sorting the command table by command length (descending), the command parser always checks for the most specific match first, resulting in correct and predictable command handling.
+
+### Flow Diagram
+
+```
+[UART RX]
+   │
+   ▼
+[HandleUartCommand(cmd)]
+   │
+   ├─► [If not sorted: InitUartCmdTableSortedIdx()]
+   │
+   ├─► For each index in uart_cmd_sorted_idx:
+   │      ├─► Compare input with uart_cmd_table[i].cmd
+   │      ├─► If match:
+   │      │      └─► Call uart_cmd_table[i].handler(param)
+   │      └─► (Continue)
+   │
+   └─► If no match: print "Unknown command"
+```
+
+- **Command handlers** are regular C functions that receive the parameter string and perform the requested action (e.g., get/set config, trigger LBS, restart, etc).
+- The command table and sorting ensure that longer (more specific) commands are matched before shorter ones (e.g., `net activate` before `net`).
+
+---
+
+### Example: `set` Command Flow
+
+The `set` command allows the user to update configuration parameters via UART. Here is how it works internally:
+
+#### Data Structures
+- **uart_cmd_entry**: Each command, including `set`, is represented in the `uart_cmd_table` as an entry:
+  ```c
+  struct uart_cmd_entry {
+      const char* cmd;           // Command string (e.g., "set")
+      int cmd_len;               // Length of the command string
+      UartCmdHandler handler;    // Pointer to the handler function
+      const char* syntax;        // Usage syntax
+      const char* help;          // Help text
+  };
+  ```
+- **uart_cmd_table**: Array of all supported commands, including `set`.
+- **ConfigStore_t**: Structure holding all configuration parameters (see `config_store.h`).
+
+#### Flow Diagram
+
+```
+[UART RX: "set apn myapn"]
+   │
+   ▼
+[HandleUartCommand(cmd)]
+   │
+   ├─► Finds "set" in uart_cmd_table (using sorted index)
+   │
+   └─► Calls HandleSetCommand(param)
+           │
+           ├─► Parses parameter name and value (e.g., "apn", "myapn")
+           ├─► Validates parameter name
+           ├─► Updates the corresponding field in ConfigStore_t
+           ├─► Optionally validates value (format, range)
+           └─► Prints confirmation or error to UART
+```
+
+#### Handler Logic (Simplified)
+- Trims whitespace from the input.
+- Extracts the parameter name and value.
+- Looks up the parameter in the configuration structure.
+- Updates the value if valid, or prints an error if not.
+- Does not persist to flash until the `save` command is issued.
+
+This approach ensures that configuration changes are robust, validated, and only applied when explicitly requested by the user.
+
+---
+

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ LOCAL_MODULE_DEPENDS += libs
 ##################################################################################
 
 PROJECT_PATH += app
-
 LOCAL_MODULE_DEPENDS += ${PROJECT_PATH}
 
 CFG_FILE = ${SOFT_WORKDIR}/${PROJECT_PATH}/config.mk

--- a/app/src/config_commands.c
+++ b/app/src/config_commands.c
@@ -17,6 +17,8 @@
 #include "utils.h"
 #include "debug.h"
 
+#define MODULE_TAG "Config"
+
 typedef void (*UartCmdHandler)(char*);
 
 void HandleHelpCommand(char*);

--- a/app/src/config_commands.c
+++ b/app/src/config_commands.c
@@ -285,7 +285,6 @@ void HandleNetworkStatusCommand(char* param)
     UART_Printf("GSM Network registered: %s, active: %s\r\n",
                 IS_GSM_REGISTERED() ? "true" : "false",
                 IS_GSM_ACTIVE() ? "true" : "false");
-    
     // Get and display IP address if network is active
     if (IS_GSM_ACTIVE()) {
         char ip_address[16] = {0};
@@ -297,17 +296,8 @@ void HandleNetworkStatusCommand(char* param)
     } else {
         UART_Printf("IP address: not available\r\n");
     }
-
-    if (g_cellInfo[0] != 0) {
-        UART_Printf("Cell info: %s\r\n", g_cellInfo);
-        // Try to parse and print cell info fields if present
-        int mcc = 0, mnc = 0, lac = 0, cellid = 0, rxlev = 0;
-        if (sscanf(g_cellInfo, "%3d,%3d,%d,%d,%d", &mcc, &mnc, &lac, &cellid, &rxlev) == 5) {
-            UART_Printf("  MCC: %03d\r\n  MNC: %03d\r\n  LAC: %d\r\n  CellID: %d\r\n  RxLev: %d\r\n",
-                mcc, mnc, lac, cellid, rxlev);
-        }
-    } else
-        UART_Printf("Cell info not available\r\n");
+    // Print cell info using network module function
+    NetworkPrintCellInfo();
 }
 
 void HandleNetworkActivateCommand(char* param)

--- a/app/src/config_commands.c
+++ b/app/src/config_commands.c
@@ -27,8 +27,6 @@ static void HandleNetworkActivateCommand(char*);
 static void HandleNetworkStatusCommand(char*);
 static void HandleNetworkDeactivateCommand(char*);
 static void HandleLocationCommand(char*);
-static void HandleLbsCommand(char*);
-static void HandleAgpsCommand(char*);
 static void HandleSmsCommand(char*);
 static void HandleSmsLsCommand(char*);
 static void HandleSmsRmCommand(char*);
@@ -55,8 +53,6 @@ static struct uart_cmd_entry uart_cmd_table[] = {
     {"sms ls",         6, HandleSmsLsCommand,           "sms ls <all|read|unread>", "list SMS messages ()"},
     {"sms rm",         6, HandleSmsRmCommand,           "sms rm <index|all>",  "remove SMS message (rm <index>) or remove all messages (rm all)"},
     {"location",       8, HandleLocationCommand,        "location",            "Show the last known GPS position"},
-    {"lbs",            3, HandleLbsCommand,             "lbs",                 "Get and print location based on seen base stations (LBS)"},
-    {"agps",           4, HandleAgpsCommand,            "agps",                "Perform assisted GPS using latest LBS location"},
     {"restart",        7, HandleRestartCommand,         "restart",             "Restart the system immediately"},
 };
 
@@ -409,27 +405,6 @@ static void HandleSmsRmCommand(char* param)
     }
 }
 
-
-static void HandleLbsCommand(char* param)
-{
-    float lat = 0.0, lon = 0.0;
-    int result = Network_GetLbsLocation(&lat, &lon);
-    if (result == 0) {
-        UART_Printf("LBS Location: Latitude: %f, Longitude: %f\r\n", lat, lon);
-    } else {
-        UART_Printf("Failed to get LBS location (error: %d)\r\n", result);
-    }
-}
-
-static void HandleAgpsCommand(char* param)
-{
-    int status = gps_PerformAgps();
-    if (status == 0) {
-        UART_Printf("AGPS success\r\n");
-    } else {
-        UART_Printf("AGPS failed\r\n");
-    }
-}
 
 void HandleUartCommand(char* cmd)
 {

--- a/app/src/config_commands.c
+++ b/app/src/config_commands.c
@@ -17,22 +17,22 @@
 
 typedef void (*UartCmdHandler)(char*);
 
-void HandleHelpCommand(char*);
-void HandleLsCommand(char*);
-void HandleRemoveFileCommand(char*);
-void HandleSetCommand(char*);
-void HandleGetCommand(char*);
-void HandleTailCommand(char*);
-void HandleRestartCommand(char*);
-void HandleNetworkActivateCommand(char*);
-void HandleNetworkStatusCommand(char*);
-void HandleNetworkDeactivateCommand(char*);
-void HandleLocationCommand(char*);
-void HandleLbsCommand(char*);
-void HandleAgpsCommand(char*);
-void HandleSmsCommand(char*);
-void HandleSmsLsCommand(char*);
-void HandleSmsRmCommand(char*);
+static void HandleHelpCommand(char*);
+static void HandleLsCommand(char*);
+static void HandleRemoveFileCommand(char*);
+static void HandleSetCommand(char*);
+static void HandleGetCommand(char*);
+static void HandleTailCommand(char*);
+static void HandleRestartCommand(char*);
+static void HandleNetworkActivateCommand(char*);
+static void HandleNetworkStatusCommand(char*);
+static void HandleNetworkDeactivateCommand(char*);
+static void HandleLocationCommand(char*);
+static void HandleLbsCommand(char*);
+static void HandleAgpsCommand(char*);
+static void HandleSmsCommand(char*);
+static void HandleSmsLsCommand(char*);
+static void HandleSmsRmCommand(char*);
 
 struct uart_cmd_entry {
     const char* cmd;
@@ -90,7 +90,7 @@ static void InitUartCmdTableSortedIdx(void)
     }
 }
 
-void HandleSetCommand(char* param)
+static void HandleSetCommand(char* param)
 {
     param = trim_whitespace(param);
     if (!*param) {
@@ -127,7 +127,7 @@ void HandleSetCommand(char* param)
     return;
 }
 
-void HandleGetCommand(char* param)
+static void HandleGetCommand(char* param)
 {
     param = trim_whitespace(param);
 
@@ -153,7 +153,7 @@ void HandleGetCommand(char* param)
     return;
 }
 
-void HandleLsCommand(char* path)
+static void HandleLsCommand(char* path)
 {
     path = trim_whitespace(path);
     if (!path || path[0] == '\0') path = "/";
@@ -205,7 +205,7 @@ void HandleLsCommand(char* path)
     API_FS_CloseDir(dir);
 }
 
-void HandleRemoveFileCommand(char* path)
+static void HandleRemoveFileCommand(char* path)
 {
     path = trim_whitespace(path);
     if (!path || path[0] == '\0') {
@@ -220,7 +220,7 @@ void HandleRemoveFileCommand(char* path)
     }
 }
 
-void HandleTailCommand(char* args)
+static void HandleTailCommand(char* args)
 {
     int bytes = 500;
     char* file_path = trim_whitespace(args);
@@ -269,7 +269,7 @@ void HandleTailCommand(char* args)
     API_FS_Close(fd);
 }
 
-void HandleLocationCommand(char* param)
+static void HandleLocationCommand(char* param)
 {
     // First check if GPS is active
     if (!IS_GPS_STATUS_ON()) {
@@ -280,7 +280,7 @@ void HandleLocationCommand(char* param)
     return;
 }
 
-void HandleNetworkStatusCommand(char* param)
+static void HandleNetworkStatusCommand(char* param)
 {
     UART_Printf("GSM Network registered: %s, active: %s\r\n",
                 IS_GSM_REGISTERED() ? "true" : "false",
@@ -300,7 +300,7 @@ void HandleNetworkStatusCommand(char* param)
     NetworkPrintCellInfo();
 }
 
-void HandleNetworkActivateCommand(char* param)
+static void HandleNetworkActivateCommand(char* param)
 {
     if (NetworkAttachActivate()) {
         UART_Printf("Network activated.\r\n");
@@ -309,7 +309,7 @@ void HandleNetworkActivateCommand(char* param)
     }
 }
 
-void HandleNetworkDeactivateCommand(char* param)
+static void HandleNetworkDeactivateCommand(char* param)
 {
     if (Network_StartDeactive(1)) {
         UART_Printf("Network deactivated.\r\n");
@@ -318,13 +318,13 @@ void HandleNetworkDeactivateCommand(char* param)
     }
 }
 
-void HandleRestartCommand(char* args)
+static void HandleRestartCommand(char* args)
 {
     UART_Printf("System restarting...\r\n");
     PM_Restart();
 }
 
-void HandleHelpCommand(char* args)
+static void HandleHelpCommand(char* args)
 {
     UART_Printf("\r\nAvailable commands:\r\n");
     for (unsigned i = 0; i < sizeof(uart_cmd_table)/sizeof(uart_cmd_table[0]); ++i) {
@@ -337,7 +337,7 @@ void HandleHelpCommand(char* args)
     UART_Printf("\r\n");
 }
 
-void HandleSmsCommand(char* param)
+static void HandleSmsCommand(char* param)
 {
     param = trim_whitespace(param);
     if (*param != '\0') {
@@ -362,7 +362,7 @@ void HandleSmsCommand(char* param)
     return;
 }
 
-void HandleSmsLsCommand(char* param)
+static void HandleSmsLsCommand(char* param)
 {
     SMS_Status_t status;
     param = trim_whitespace(param);
@@ -382,7 +382,7 @@ void HandleSmsLsCommand(char* param)
     return;
 }
 
-void HandleSmsRmCommand(char* param)
+static void HandleSmsRmCommand(char* param)
 {
     param = trim_whitespace(param);
     if (*param != '\0') {
@@ -401,19 +401,8 @@ void HandleSmsRmCommand(char* param)
     }
 }
 
-// Print SMS list message
-void HandleSmsListEvent(SMS_Message_Info_t* msg)
-{
-    UART_Printf("\r\n[SMS index: %d]\r\nFrom: %s\r\nTime: %u/%02u/%02u,%02u:%02u:%02u+%02d\r\nContent: %.*s\r\n\r\n",
-                msg->index,
-                msg->phoneNumber,
-                msg->time.year, msg->time.month, msg->time.day,
-                msg->time.hour, msg->time.minute, msg->time.second,
-                msg->time.timeZone,
-                msg->dataLen, msg->data ? (char*)msg->data : "");
-}
 
-void HandleLbsCommand(char* param)
+static void HandleLbsCommand(char* param)
 {
     float lat = 0.0, lon = 0.0;
     int result = Network_GetLbsLocation(&lat, &lon);
@@ -424,7 +413,7 @@ void HandleLbsCommand(char* param)
     }
 }
 
-void HandleAgpsCommand(char* param)
+static void HandleAgpsCommand(char* param)
 {
     int status = gps_PerformAgps();
     if (status == 0) {
@@ -448,4 +437,16 @@ void HandleUartCommand(char* cmd)
         }
     }
     UART_Printf("Unknown command. Type 'help' to see available commands.\r\n");
+}
+
+// Print SMS list message
+void SmsListMessageCallback(SMS_Message_Info_t* msg)
+{
+    UART_Printf("\r\n[SMS index: %d]\r\nFrom: %s\r\nTime: %u/%02u/%02u,%02u:%02u:%02u+%02d\r\nContent: %.*s\r\n\r\n",
+                msg->index,
+                msg->phoneNumber,
+                msg->time.year, msg->time.month, msg->time.day,
+                msg->time.hour, msg->time.minute, msg->time.second,
+                msg->time.timeZone,
+                msg->dataLen, msg->data ? (char*)msg->data : "");
 }

--- a/app/src/config_commands.h
+++ b/app/src/config_commands.h
@@ -4,6 +4,6 @@
 #include "config_store.h"
 
 void HandleUartCommand(char* cmd);
-void HandleSmsListEvent(SMS_Message_Info_t* msg);
+void SmsListMessageCallback(SMS_Message_Info_t* msg);
 
 #endif

--- a/app/src/config_store.c
+++ b/app/src/config_store.c
@@ -7,12 +7,11 @@
 #include <api_fs.h>
 #include <api_info.h>
 
+#include "utils.h"
 #include "gps_tracker.h"
 #include "config_store.h"
 #include "config_commands.h"
 #include "config_validation.h"
-#include "minmea.h"
-#include "utils.h"
 #include "debug.h"
 
 #define MODULE_TAG "Config"

--- a/app/src/config_store.c
+++ b/app/src/config_store.c
@@ -15,6 +15,8 @@
 #include "utils.h"
 #include "debug.h"
 
+#define MODULE_TAG "Config"
+
 t_Config g_ConfigStore;
 
 static bool parse_line(char* line)

--- a/app/src/config_store.h
+++ b/app/src/config_store.h
@@ -21,28 +21,6 @@
 #define PARAM_GPS_UERE              "gps_uere"
 #define PARAM_GPS_LOGS              "gps_logging"
 
-// Protocol
-typedef enum {
-    PROT_HTTP = 0,
-    PROT_HTTPS
-} t_protocol;
-
-// Log levels
-typedef enum {
-    LOG_LEVEL_NONE = 0,
-    LOG_LEVEL_ERROR,
-    LOG_LEVEL_WARN,
-    LOG_LEVEL_INFO,
-    LOG_LEVEL_DEBUG
-} t_logLevel;
-
-// Log output
-typedef enum {
-    LOGGER_OUTPUT_UART = 0,
-    LOGGER_OUTPUT_TRACE,
-    LOGGER_OUTPUT_FILE
-} t_logOutput;
-
 typedef struct {
     char        imei[MAX_IMEI_LENGTH];
     char        device_name[MAX_DEVICE_NAME_LENGTH];

--- a/app/src/config_store.h
+++ b/app/src/config_store.h
@@ -8,6 +8,7 @@
 #define MAX_APN_USER_LENGTH         32
 #define MAX_DEVICE_NAME_LENGTH      32
 #define MAX_IMEI_LENGTH             16
+#define MAX_GPS_LOG_PATH_LENGTH     128
 
 #define PARAM_DEVICE_NAME           "device_name"
 #define PARAM_SERVER_ADDR           "server"
@@ -20,6 +21,8 @@
 #define PARAM_LOG_OUTPUT            "log_output"
 #define PARAM_GPS_UERE              "gps_uere"
 #define PARAM_GPS_LOGS              "gps_logging"
+#define PARAM_GPS_LOG_FILE          "gps_log_file"
+#define PARAM_GPS_PRINT_POS         "gps_print_pos"
 
 typedef struct {
     char        imei[MAX_IMEI_LENGTH];
@@ -31,7 +34,9 @@ typedef struct {
     char        apn_user[MAX_APN_USER_LENGTH];
     char        apn_pass[MAX_APN_USER_LENGTH];
     float       gps_uere;
+    bool        gps_print_pos;
     bool        gps_logging;
+    char        gps_log_file[MAX_GPS_LOG_PATH_LENGTH];
     t_logLevel  logLevel;
     t_logOutput logOutput;
 } t_Config;

--- a/app/src/config_validation.c
+++ b/app/src/config_validation.c
@@ -1,9 +1,8 @@
 #include "gps.h"
+#include "utils.h"
 #include "gps_tracker.h"
 #include "config_store.h"
 #include "config_validation.h"
-#include "minmea.h"
-#include "utils.h"
 #include "debug.h"
 
 // Validators

--- a/app/src/config_validation.c
+++ b/app/src/config_validation.c
@@ -40,7 +40,7 @@ const t_config_map g_config_map[] = {
     {PARAM_GPS_UERE,        DEFAULT_GPS_UERE,        GpsUereValidate,     FloatSerializer,     &g_ConfigStore.gps_uere},
     {PARAM_GPS_LOGS,        DEFAULT_GPS_LOGS,        GpsLoggingValidate,  BoolSerializer,      &g_ConfigStore.gps_logging},
     {PARAM_GPS_LOG_FILE,    DEFAULT_GPS_LOG_FILE,    GpsLogFileValidate,  StringSerializer,    &g_ConfigStore.gps_log_file},
-    {PARAM_GPS_PRINT_POS,   DEFAULT_GPS_PRINT_POS,   GpsPrintPosValidate, BoolSerializer,      &g_ConfigStore.gps_print_pos}
+    {PARAM_GPS_PRINT_POS,   DEFAULT_GPS_PRINT_POS,   GpsPrintPosValidate, BoolSerializer,      &g_ConfigStore.gps_print_pos},
 };
 
 const size_t g_config_map_size = sizeof(g_config_map)/sizeof(g_config_map[0]);
@@ -327,6 +327,7 @@ const char* LogOutputSerializer(const void* value)
 const char* BoolSerializer(const void* value)
 {
     if (!value) return NULL;
-    snprintf(serializer_buf, sizeof(serializer_buf), "%s", *((const int*)value) ? "true" : "false");
+    // Cast to unsigned char for bool fields (avoids alignment issues)
+    snprintf(serializer_buf, sizeof(serializer_buf), "%s", (*(const unsigned char*)value) ? "true" : "false");
     return serializer_buf;
 }

--- a/app/src/config_validation.c
+++ b/app/src/config_validation.c
@@ -1,14 +1,10 @@
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-
+#include "gps.h"
 #include "gps_tracker.h"
 #include "config_store.h"
 #include "config_validation.h"
 #include "minmea.h"
 #include "utils.h"
 #include "debug.h"
-#include "gps.h"
 
 // Validators
 bool DeviceNameValidate(const char* value);

--- a/app/src/debug.c
+++ b/app/src/debug.c
@@ -1,9 +1,9 @@
 #include <api_fs.h>
 #include <api_hal_uart.h>
 
+#include "utils.h"
 #include "config_store.h"
 #include "config_validation.h"
-#include "minmea.h"
 #include "debug.h"
 
 int32_t g_log_file;

--- a/app/src/debug.c
+++ b/app/src/debug.c
@@ -1,13 +1,7 @@
-#include <stdio.h>
-#include <ctype.h>
-#include <stdarg.h>
-#include <string.h>
-
 #include <api_fs.h>
 #include <api_hal_uart.h>
 
 #include "config_store.h"
-#include "config_commands.h"
 #include "config_validation.h"
 #include "minmea.h"
 #include "debug.h"

--- a/app/src/debug.c
+++ b/app/src/debug.c
@@ -8,7 +8,7 @@
 
 int32_t g_log_file;
 
-void UART_Printf(const char* fmt, ...) 
+int32_t UART_Printf(const char* fmt, ...) 
 {
     char buffer[LOG_LEVEL_BUFFER_SIZE];
     va_list args;
@@ -23,7 +23,7 @@ void UART_Printf(const char* fmt, ...)
 
         UART_Write(UART1, buffer, (size_t)len);
     }
-    return;
+    return 0;
 }
 
 int32_t FILE_Printf(const char* fmt, ...)

--- a/app/src/debug.h
+++ b/app/src/debug.h
@@ -6,6 +6,7 @@
 extern int32_t      g_log_file;
 
 void UART_Printf(const char* fmt, ...) ;
+int32_t FILE_Printf(const char* fmt, ...);
 
 void log_message_internal(t_logLevel level, const char *func, const char *format, ...);
 #define LOG(level, format, ...) \

--- a/app/src/debug.h
+++ b/app/src/debug.h
@@ -5,7 +5,7 @@
 
 extern int32_t      g_log_file;
 
-void UART_Printf(const char* fmt, ...) ;
+int32_t UART_Printf(const char* fmt, ...) ;
 int32_t FILE_Printf(const char* fmt, ...);
 
 void log_message_internal(t_logLevel level, const char *func, const char *format, ...);

--- a/app/src/gps_tracker.c
+++ b/app/src/gps_tracker.c
@@ -209,26 +209,3 @@ void gps_TrackerTask(void *pData)
     }
 }
 
-// Returns 0 on success, nonzero on failure
-int gps_PerformAgps(void)
-{
-    float latitude = 0.0, longitude = 0.0;
-    int lbs_ok = Network_GetLbsLocation(&longitude, &latitude);
-    if (!lbs_ok) {
-        UART_Printf("LBS get location failed.\r\n");
-        longitude = gps_GetLastLongitude();
-        latitude = gps_GetLastLatitude();
-        UART_Printf("Last known position: lat: %.6f, lon: %.6f\r\n",
-                    latitude, longitude);
-    } else {
-        UART_Printf("Network based position: lat: %.6f, lon: %.6f\r\n",
-                    latitude, longitude);
-    }
-    // Call AGPS
-    if (!GPS_AGPS(latitude, longitude, 0, true)) {
-        UART_Printf("Assisted GPS start failed\n\r");
-        return -1; // AGPS failed
-    }
-    UART_Printf("Assisted GPS start succeeded\n\r");
-    return 0; // AGPS success
-}

--- a/app/src/gps_tracker.c
+++ b/app/src/gps_tracker.c
@@ -153,8 +153,9 @@ void gps_TrackerTask(void *pData)
             gps_PrintLocation();
 
             responseBuffer[0] = '\0';
-            if (strlen(g_cellInfo) != 0)
-                snprintf(responseBuffer, sizeof(responseBuffer),"&cell=%s", g_cellInfo);
+            const char* cellInfoStr = Network_GetCellInfoString();
+            if (cellInfoStr && strlen(cellInfoStr) != 0)
+                snprintf(responseBuffer, sizeof(responseBuffer),"&cell=%s", cellInfoStr);
 
             snprintf(requestBuffer, sizeof(requestBuffer),
                 "id=%s&valid=%d&timestamp=%d&lat=%f&lon=%f&speed=%1.f&bearing=%.1f&altitude=%.1f&accuracy=%.1f%s&batt=%d",

--- a/app/src/gps_tracker.c
+++ b/app/src/gps_tracker.c
@@ -60,7 +60,7 @@ void gps_Process(void)
 
 void gps_PrintLocation(t_logOutput output)
 {
-    void (*print_func)(const char*, ...) = NULL;
+    int (*print_func)(const char*, ...) = NULL;
     switch (output) {
         case LOGGER_OUTPUT_UART:
             print_func = UART_Printf;

--- a/app/src/gps_tracker.c
+++ b/app/src/gps_tracker.c
@@ -168,7 +168,8 @@ void gps_TrackerTask(void *pData)
             uint8_t percent;
             PM_Voltage(&percent);
 
-            gps_PrintLocation(g_ConfigStore.logOutput);
+            if (g_ConfigStore.gps_print_pos)
+                gps_PrintLocation(LOGGER_OUTPUT_UART);
 
             responseBuffer[0] = '\0';
             const char* cellInfoStr = Network_GetCellInfoString();

--- a/app/src/gps_tracker.c
+++ b/app/src/gps_tracker.c
@@ -66,7 +66,7 @@ void gps_PrintLocation(void)
         UART_Printf("%02d.%02d.%02d, ", gpsInfo->rmc.time.hours, gpsInfo->rmc.time.minutes, gpsInfo->rmc.time.seconds);
     }
     UART_Printf("sat visble:%d, sat tracked:%d, err: %.1f, ", gpsInfo->gsv[0].total_sats, gpsInfo->gga.satellites_tracked, GpsTrackerData.accuracy);
-    UART_Printf("lat: %.6f° %c, lon: %.6f° %c, ", (float)fabs(GpsTrackerData.latitude),  (char)((GpsTrackerData.latitude  >= 0) ? 'N' : 'S'),
+    UART_Printf("lat: %.6f deg %c, lon: %.6f deg %c, ", (float)fabs(GpsTrackerData.latitude),  (char)((GpsTrackerData.latitude  >= 0) ? 'N' : 'S'),
                                                   (float)fabs(GpsTrackerData.longitude), (char)((GpsTrackerData.longitude >= 0) ? 'E' : 'W'));
     UART_Printf("alt:%.1f, spd:%.1f, hdg:%.1f\r\n",  GpsTrackerData.altitude, GpsTrackerData.speed, GpsTrackerData.bearing);
     return;

--- a/app/src/gps_tracker.c
+++ b/app/src/gps_tracker.c
@@ -78,11 +78,10 @@ void gps_PrintLocation(t_logOutput output)
 
     if (!gpsInfo->rmc.valid) {
         print_func("INVALID, ");
-    } 
-    
-    print_func("%02d.%02d.%02d ", gpsInfo->rmc.date.year, gpsInfo->rmc.date.month, gpsInfo->rmc.date.day);
-    print_func("%02d.%02d.%02d, ", gpsInfo->rmc.time.hours, gpsInfo->rmc.time.minutes, gpsInfo->rmc.time.seconds);
-    
+    } else {
+        print_func("%02d.%02d.%02d ", gpsInfo->rmc.date.year, gpsInfo->rmc.date.month, gpsInfo->rmc.date.day);
+        print_func("%02d.%02d.%02d, ", gpsInfo->rmc.time.hours, gpsInfo->rmc.time.minutes, gpsInfo->rmc.time.seconds);
+    }
     print_func("sat visble:%d, sat tracked:%d, err: %.1f, ", gpsInfo->gsv[0].total_sats, gpsInfo->gga.satellites_tracked, GpsTrackerData.accuracy);
     print_func("lat: %.6f° %c, lon: %.6f° %c, ", (float)fabs(GpsTrackerData.latitude),  (char)((GpsTrackerData.latitude  >= 0) ? 'N' : 'S'),
               (float)fabs(GpsTrackerData.longitude), (char)((GpsTrackerData.longitude >= 0) ? 'E' : 'W'));
@@ -120,14 +119,14 @@ void gps_TrackerTask(void *pData)
     LOGI("Waiting for GPS");
     while(!IS_GPS_STATUS_ON()) OS_Sleep(2000);
 
+    RTC_Time_t time;
+    TIME_GetRtcTime(&time);
+    if(!GPS_SetRtcTime(&time)) LOGE("set gps time failed");
+
     if(!GPS_GetVersion(responseBuffer, 255))
         LOGE("get GPS firmware version failed");
     else
         LOGW("GPS firmware version: %s", responseBuffer);
-   
-    RTC_Time_t time;
-    TIME_GetRtcTime(&time);
-    if(!GPS_SetRtcTime(&time)) LOGE("set gps time failed");
 
     GPS_SetSearchMode(true, false, true, true);
 

--- a/app/src/gps_tracker.c
+++ b/app/src/gps_tracker.c
@@ -153,9 +153,8 @@ void gps_TrackerTask(void *pData)
             gps_PrintLocation();
 
             responseBuffer[0] = '\0';
-            if (strlen(g_cellInfo) != 0) {
+            if (strlen(g_cellInfo) != 0)
                 snprintf(responseBuffer, sizeof(responseBuffer),"&cell=%s", g_cellInfo);
-            }
 
             snprintf(requestBuffer, sizeof(requestBuffer),
                 "id=%s&valid=%d&timestamp=%d&lat=%f&lon=%f&speed=%1.f&bearing=%.1f&altitude=%.1f&accuracy=%.1f%s&batt=%d",
@@ -185,9 +184,7 @@ void gps_TrackerTask(void *pData)
             desired_interval = 1;
         }
 
-        uint32_t loop_end = time(NULL);
-        uint32_t loop_duration = (loop_end - g_trackerloop_tick);
-
+        uint32_t loop_duration = (time(NULL) - g_trackerloop_tick);
         if (loop_duration > desired_interval) loop_duration = desired_interval;
         OS_Sleep((desired_interval - loop_duration) * 1000);
     }

--- a/app/src/gps_tracker.h
+++ b/app/src/gps_tracker.h
@@ -59,4 +59,6 @@ void  gps_PrintLocation(void);
 
 void  gps_TrackerTask(void *pData);
 
+int   gps_PerformAgps(void);
+
 #endif

--- a/app/src/gps_tracker.h
+++ b/app/src/gps_tracker.h
@@ -2,8 +2,6 @@
 #define GPS_TRACKER_H
 
 #define CONFIG_FILE_PATH          "/config.ini"
-#define GPS_NMEA_LOG_FILE_PATH    "/t/gps_nmea.log"
-
 #define DEFAULT_APN_VALUE         "internet"
 #define DEFAULT_APN_PASS_VALUE    ""
 #define DEFAULT_APN_USER_VALUE    ""
@@ -13,6 +11,8 @@
 #define DEFAULT_DEVICE_NAME       "IMEI"
 #define DEFAULT_GPS_UERE          "5"
 #define DEFAULT_GPS_LOGS          "disabled"
+#define DEFAULT_GPS_LOG_FILE      "/t/gps_nmea.log"
+#define DEFAULT_GPS_PRINT_POS     "disabled"
 #define DEFAULT_LOG_LEVEL         "info"
 #define DEFAULT_LOG_OUTPUT        "uart"
 

--- a/app/src/gps_tracker.h
+++ b/app/src/gps_tracker.h
@@ -55,7 +55,12 @@ float gps_GetLastLongitude(void);
  */
 void  gps_Process(void);
 
-void  gps_PrintLocation(void);
+/**
+ * @brief Print the current GPS location to the selected output.
+ * This function prints the formatted GPS information to UART, Trace, or file depending on the output argument.
+ * @param output The log output type (UART, TRACE, or FILE)
+ */
+void  gps_PrintLocation(t_logOutput output);
 
 void  gps_TrackerTask(void *pData);
 

--- a/app/src/gps_tracker.h
+++ b/app/src/gps_tracker.h
@@ -31,6 +31,12 @@ extern uint32_t g_trackerloop_tick;
  */
 void  gps_Init(void);
 
+/**
+ * @brief Check if the GPS data is valid.
+ * This function checks the validity of the GPS data by verifying the status
+ * reported by the GPS module.
+ * @return true if the GPS data is valid, false otherwise
+ */
 bool  gps_isValid(void);
 
 /**
@@ -62,8 +68,13 @@ void  gps_Process(void);
  */
 void  gps_PrintLocation(t_logOutput output);
 
+/**
+ * @brief The main task for the GPS tracker.
+ * This function runs in a loop, checking for GPS and GSM status,
+ * and sending location updates to the server at specified intervals.
+ * It should be started as a separate task in the system.
+ * @param pData Pointer to task data (not used)
+ */
 void  gps_TrackerTask(void *pData);
-
-int   gps_PerformAgps(void);
 
 #endif

--- a/app/src/http.c
+++ b/app/src/http.c
@@ -3,7 +3,6 @@
 
 #include <api_os.h>
 #include <api_socket.h>
-#include <api_hal_uart.h>
 #include <api_ssl.h>
 
 #include "http.h"

--- a/app/src/http.c
+++ b/app/src/http.c
@@ -217,7 +217,7 @@ int Http_Post(bool          secure,
     const char* fmt = "POST %s HTTP/1.1\r\n"
                       "Host: %s\r\n"
                       "Content-Type: application/x-www-form-urlencoded\r\n"
-                      "Connection: close\r\n"
+                      "Connection: Keep-Alive\r\n"
                       "Content-Length: %d\r\n\r\n%s";
 
     // Calculate the required buffer size

--- a/app/src/http.c
+++ b/app/src/http.c
@@ -5,6 +5,8 @@
 #include <api_socket.h>
 #include <api_ssl.h>
 
+
+#include "utils.h"
 #include "http.h"
 #include "config_store.h"
 #include "debug.h"

--- a/app/src/http.c
+++ b/app/src/http.c
@@ -220,7 +220,7 @@ int Http_Post(bool          secure,
                       "Host: %s\r\n"
                       "Content-Type: application/x-www-form-urlencoded\r\n"
                       "Connection: Keep-Alive\r\n"
-                      "Content-Length: %d\r\n\r\n%s";
+                      "Content-Length: %d\r\n\r\n%s\r\n";
 
     // Calculate the required buffer size
     int bufferLen = snprintf(NULL, 0, fmt, path, hostName, dataLen, data);

--- a/app/src/led_handler.c
+++ b/app/src/led_handler.c
@@ -2,6 +2,7 @@
 #include <api_hal_gpio.h>
 
 #include "system.h"
+#include "utils.h"
 #include "gps_tracker.h"
 #include "led_handler.h"
 

--- a/app/src/network.c
+++ b/app/src/network.c
@@ -17,14 +17,6 @@
 
 #define MODULE_TAG "Network"
 
-/*
- * @brief Global variable to store cell information.
- *
- * This variable is used to hold the formatted cell information string
- * that can be accessed by other parts of the application.  
- */
-char    g_cellInfoStr[128] = "\0";
-
 static bool apn_workaround_pending = false;  
 #define MAX_CELLINFO_COUNT 8
 
@@ -34,9 +26,17 @@ static Network_Location_t    g_CellInfo[MAX_CELLINFO_COUNT];
 static uint8_t               g_CellInfoCount = 0;
 static uint8_t               g_RSSI = 0;
 
+/*
+ * @brief Global variable to store cell information.
+ *
+ * This variable is used to hold the formatted cell information string
+ * that can be accessed by other parts of the application.  
+ */
+static char g_cellInfoStr[128] = "\0";
+
 static void NetworkMonitorTimer(HANDLE);
 
-void NetworkMonitor(void* param)
+static void NetworkMonitor(void* param)
 {
     if (param == NULL) return;
 

--- a/app/src/network.c
+++ b/app/src/network.c
@@ -9,11 +9,10 @@
 #include <api_lbs.h>
 
 #include "system.h"
+#include "utils.h"
 #include "gps_tracker.h"
 #include "config_store.h"
 #include "network.h"
-#include "minmea.h"
-#include "utils.h"
 #include "debug.h"
 
 #define MODULE_TAG "Network"

--- a/app/src/network.c
+++ b/app/src/network.c
@@ -11,15 +11,28 @@
 #include "gps_tracker.h"
 #include "config_store.h"
 #include "network.h"
+#include "minmea.h"
+#include "utils.h"
 #include "debug.h"
 
 #define MODULE_TAG "Network"
 
-uint8_t g_RSSI = 0;
-char    g_cellInfo[128] = "\0";
-static Network_Status_t g_NetworkStatus = 0;
-static Network_PDP_Context_t NetContextArr[2]; // Two-element array: [0]=real APN, [1]=dummy APN
+/*
+ * @brief Global variable to store cell information.
+ *
+ * This variable is used to hold the formatted cell information string
+ * that can be accessed by other parts of the application.  
+ */
+char    g_cellInfoStr[128] = "\0";
+
 static bool apn_workaround_pending = false;  
+#define MAX_CELLINFO_COUNT 8
+
+static Network_Status_t      g_NetworkStatus = 0;
+static Network_PDP_Context_t g_NetContextArr[2]; // Two-element array: [0]=real APN, [1]=dummy APN
+static Network_Location_t    g_CellInfo[MAX_CELLINFO_COUNT];
+static uint8_t               g_CellInfoCount = 0;
+static uint8_t               g_RSSI = 0;
 
 static void NetworkMonitorTimer(HANDLE);
 
@@ -42,11 +55,11 @@ void NetworkMonitor(void* param)
 
     if (IS_GSM_REGISTERED()) {
         if(!Network_GetCellInfoRequst()) {
-            g_cellInfo[0] = '\0';
+            g_cellInfoStr[0] = '\0';
             LOGE("network get cell info fail");
         }
     } else {
-        g_cellInfo[0] = '\0';
+        g_cellInfoStr[0] = '\0';
     }
     HANDLE taskHandle = (HANDLE)param;
     NetworkMonitorTimer(taskHandle);
@@ -57,12 +70,48 @@ static void NetworkMonitorTimer(HANDLE taskHandle)
     OS_StartCallbackTimer(taskHandle, NETWORK_MONITOR_INTERVAL_MS, NetworkMonitor, (void*)taskHandle);
 }
 
+void NetworkSigQualityCallback(int CSQ)
+{
+    g_RSSI = csq_to_percent(CSQ);
+    LOGD("Signal Quality: %d%%", g_RSSI);
+    return;
+}
+
 void NetworkCellInfoCallback(Network_Location_t* loc, int number)
 {
-    g_cellInfo[0] = '\0';
+    g_cellInfoStr[0] = '\0';
+    g_CellInfoCount = 0;
     if (number <= 0) return;
-    snprintf(g_cellInfo,  sizeof(g_cellInfo), "%u%u%u,%u%u%u,%u,%u,%d",
-             loc->sMcc[0], loc->sMcc[1], loc->sMcc[2], loc->sMnc[0], loc->sMnc[1], loc->sMnc[2], loc->sLac, loc->sCellID, loc->iRxLev);
+    int count = (number > MAX_CELLINFO_COUNT) ? MAX_CELLINFO_COUNT : number;
+    for (int i = 0; i < count; ++i) {
+        g_CellInfo[i] = loc[i];
+    }
+    g_CellInfoCount = count;
+    // Format the serving cell for UART output (first entry)
+    snprintf(g_cellInfoStr, sizeof(g_cellInfoStr), "%u%u%u,%u%u%u,%u,%u,%d",
+             g_CellInfo[0].sMcc[0], g_CellInfo[0].sMcc[1], g_CellInfo[0].sMcc[2],
+             g_CellInfo[0].sMnc[0], g_CellInfo[0].sMnc[1], g_CellInfo[0].sMnc[2],
+             g_CellInfo[0].sLac, g_CellInfo[0].sCellID, g_CellInfo[0].iRxLev);
+}
+
+void NetworkPrintCellInfo(void)
+{
+    if (g_CellInfoCount > 0) {
+        UART_Printf("Base stations seen: %d\r\n", g_CellInfoCount);
+        for (uint8_t i = 0; i < g_CellInfoCount; ++i) {
+            UART_Printf("  [%d] MCC: %u%u%u, MNC: %u%u%u, LAC: %u, CellID: %u, RxLev: %d\r\n", i,
+                g_CellInfo[i].sMcc[0], g_CellInfo[i].sMcc[1], g_CellInfo[i].sMcc[2],
+                g_CellInfo[i].sMnc[0], g_CellInfo[i].sMnc[1], g_CellInfo[i].sMnc[2],
+                g_CellInfo[i].sLac, g_CellInfo[i].sCellID, g_CellInfo[i].iRxLev);
+        }
+    } else {
+        UART_Printf("Cell info not available\r\n");
+    }
+}
+
+const char* Network_GetCellInfoString(void)
+{
+    return g_cellInfoStr;
 }
 
 // the function is called whenever the network state changes
@@ -144,8 +193,8 @@ void NetworkInit(HANDLE taskHandle)
     apn_workaround_pending = false;
 
     // Dummy APN (index 1) context is set once at system init
-    memset(&NetContextArr[1], 0, sizeof(NetContextArr[1]));
-    strncpy(NetContextArr[1].apn, "dummy_apn", sizeof(NetContextArr[1].apn)-1);
+    memset(&g_NetContextArr[1], 0, sizeof(g_NetContextArr[1]));
+    strncpy(g_NetContextArr[1].apn, "dummy_apn", sizeof(g_NetContextArr[1].apn)-1);
 
     NetworkMonitorTimer(taskHandle);
 
@@ -156,10 +205,10 @@ void NetworkInit(HANDLE taskHandle)
 // Helper to initialize the real APN context
 static void SetApnContext() {
     // Real APN (index 0)
-    memset(&NetContextArr[0], 0, sizeof(NetContextArr[0]));
-    strncpy(NetContextArr[0].apn, g_ConfigStore.apn, sizeof(NetContextArr[0].apn)-1);
-    strncpy(NetContextArr[0].userName, g_ConfigStore.apn_user, sizeof(NetContextArr[0].userName)-1);
-    strncpy(NetContextArr[0].userPasswd, g_ConfigStore.apn_pass, sizeof(NetContextArr[0].userPasswd)-1);
+    memset(&g_NetContextArr[0], 0, sizeof(g_NetContextArr[0]));
+    strncpy(g_NetContextArr[0].apn, g_ConfigStore.apn, sizeof(g_NetContextArr[0].apn)-1);
+    strncpy(g_NetContextArr[0].userName, g_ConfigStore.apn_user, sizeof(g_NetContextArr[0].userName)-1);
+    strncpy(g_NetContextArr[0].userPasswd, g_ConfigStore.apn_pass, sizeof(g_NetContextArr[0].userPasswd)-1);
 }
 
 bool NetworkAttachActivate()
@@ -209,12 +258,12 @@ bool NetworkAttachActivate()
             LOGI("Using valid APN to activate the network");
             SetApnContext();
             NetworkUpdateStatus(NETWORK_STATUS_ACTIVATING);
-            ret = Network_StartActive(NetContextArr[0]); // real APN
+            ret = Network_StartActive(g_NetContextArr[0]); // real APN
             apn_workaround_pending = true;
         } else {
             LOGI("Using dummy APN to workaround re-activation defect");
             NetworkUpdateStatus(NETWORK_STATUS_ACTIVATING);
-            ret = Network_StartActive(NetContextArr[1]); // dummy
+            ret = Network_StartActive(g_NetContextArr[1]); // dummy
             apn_workaround_pending = false;
         }
         if (!ret) {
@@ -224,3 +273,4 @@ bool NetworkAttachActivate()
     }
     return true;
 }
+

--- a/app/src/network.c
+++ b/app/src/network.c
@@ -273,13 +273,3 @@ bool NetworkAttachActivate()
     }
     return true;
 }
-
-int Network_GetLbsLocation(float* lat, float* lon)
-{
-    if (!lat || !lon) return -2;
-    if (g_CellInfoCount == 0) return -1;
-    if (!LBS_GetLocation(g_CellInfo, g_CellInfoCount, 15, lon, lat))
-        return -3;
-    return 0;
-}
-

--- a/app/src/network.c
+++ b/app/src/network.c
@@ -6,6 +6,7 @@
 #include <api_os.h>
 #include <api_network.h>
 #include <api_hal_uart.h>
+#include <api_lbs.h>
 
 #include "system.h"
 #include "gps_tracker.h"
@@ -272,5 +273,14 @@ bool NetworkAttachActivate()
         }
     }
     return true;
+}
+
+int Network_GetLbsLocation(float* lat, float* lon)
+{
+    if (!lat || !lon) return -2;
+    if (g_CellInfoCount == 0) return -1;
+    if (!LBS_GetLocation(g_CellInfo, g_CellInfoCount, 15, lon, lat))
+        return -3;
+    return 0;
 }
 

--- a/app/src/network.h
+++ b/app/src/network.h
@@ -68,4 +68,11 @@ const char* Network_GetCellInfoString(void);
  */
 void NetworkPrintCellInfo(void);
 
+/**
+ * Get LBS (cell-based) location using current cell info.
+ * Returns 0 on success, nonzero on failure.
+ * lat/lon are output parameters.
+ */
+int Network_GetLbsLocation(float* lat, float* lon);
+
 #endif

--- a/app/src/network.h
+++ b/app/src/network.h
@@ -1,8 +1,6 @@
 #ifndef NETWORK_H
 #define NETWORK_H
 
-
-
 /**
  * @brief Setups capturing network state.
  * 
@@ -33,7 +31,7 @@ Network_Status_t NetworkGetStatus(void);
 /**
  * @brief Callback function to handle network cell information updates.
  * 
- * This function should be called by the event handler functionfor each
+ * This function should be called by the event handler function for each
  * API_EVENT_ID_NETWORK_CELL_INFO event. It formats the cell information into a string
  * and stores it in the global `g_cellInfo` variable.
  */
@@ -53,22 +51,20 @@ void NetworkCellInfoCallback(Network_Location_t* loc, int number);
 void NetworkSigQualityCallback(int CSQ);
 
 /**
- * @brief Prints the current Base Statsion information to the UART.
+ * @brief Gets the current cell information as a formatted string.
+ *
+ * This function retrieves the cell information last received and 
+ * formats it into a string representation.
  * 
- * This function formats the cell information stored in the global `g_cellInfo` variable
- * and prints it to the UART for debugging or monitoring purposes.  
- * It includes details such as MCC, MNC, LAC, Cell ID, and RxLev.
- * If no cell information is available, it prints a message indicating that.
+ * @return A pointer to a string containing the cell information in the format "MCC,MNC,LAC,CellID,RxLev". 
  */
 const char* Network_GetCellInfoString(void);
 
 /**
  * @brief Prints information on all visible BaseStations to the UART.
  * 
- * This function formats the cell information stored in the global `g_cellInfo` variable
- * and prints it to the UART for debugging or monitoring purposes.  
+ * This function prints  to the UART information on all basestations seen by the device.
  * It includes details such as MCC, MNC, LAC, Cell ID, and RxLev.
- * If no cell information is available, it prints a message indicating that.
  */
 void NetworkPrintCellInfo(void);
 

--- a/app/src/network.h
+++ b/app/src/network.h
@@ -68,11 +68,4 @@ const char* Network_GetCellInfoString(void);
  */
 void NetworkPrintCellInfo(void);
 
-/**
- * Get LBS (cell-based) location using current cell info.
- * Returns 0 on success, nonzero on failure.
- * lat/lon are output parameters.
- */
-int Network_GetLbsLocation(float* lat, float* lon);
-
 #endif

--- a/app/src/network.h
+++ b/app/src/network.h
@@ -1,13 +1,7 @@
 #ifndef NETWORK_H
 #define NETWORK_H
 
-/*
- * @brief Global variable to store cell information.
- *
- * This variable is used to hold the formatted cell information string
- * that can be accessed by other parts of the application.  
- */
-extern char g_cellInfo[];
+
 
 /**
  * @brief Setups capturing network state.
@@ -45,6 +39,37 @@ Network_Status_t NetworkGetStatus(void);
  */
 void NetworkCellInfoCallback(Network_Location_t* loc, int number);
 
-extern uint8_t g_RSSI;
+/**
+ * @brief Callback function to handle network signal quality updates.
+ * 
+ * This function converts the CSQ value to a percentage and logs it.
+ * it is called whenever the signal quality changes.
+ * It updates the global signal strength variable `g_RSSI` based on the received CSQ value.
+ *
+ * @param CSQ The received signal quality value (CSQ).
+ * @note The CSQ value is typically in the range of 0-31, where 0 indicates no signal and 31 indicates the best signal quality.
+ * 
+ */
+void NetworkSigQualityCallback(int CSQ);
+
+/**
+ * @brief Prints the current Base Statsion information to the UART.
+ * 
+ * This function formats the cell information stored in the global `g_cellInfo` variable
+ * and prints it to the UART for debugging or monitoring purposes.  
+ * It includes details such as MCC, MNC, LAC, Cell ID, and RxLev.
+ * If no cell information is available, it prints a message indicating that.
+ */
+const char* Network_GetCellInfoString(void);
+
+/**
+ * @brief Prints information on all visible BaseStations to the UART.
+ * 
+ * This function formats the cell information stored in the global `g_cellInfo` variable
+ * and prints it to the UART for debugging or monitoring purposes.  
+ * It includes details such as MCC, MNC, LAC, Cell ID, and RxLev.
+ * If no cell information is available, it prints a message indicating that.
+ */
+void NetworkPrintCellInfo(void);
 
 #endif

--- a/app/src/sms_service.c
+++ b/app/src/sms_service.c
@@ -11,12 +11,11 @@
 #include <api_hal_uart.h>
 
 #include "system.h"
+#include "utils.h"
 #include "gps_parse.h"
 #include "gps_tracker.h"
 #include "config_store.h"
 #include "sms_service.h"
-#include "minmea.h"
-#include "utils.h"
 #include "debug.h"
 
 #define MODULE_TAG "SMS"

--- a/app/src/sms_service.h
+++ b/app/src/sms_service.h
@@ -1,8 +1,16 @@
 #ifndef SMS_SERVICE_H
 #define SMS_SERVICE_H
 
-void SMSInit();
-void HandleSmsReceived(API_Event_t* pEvent);
+void SmsInit();
+// Callback for SMS reception
+// This function will be called when an SMS is received
+// it parses the SMS header and content,
+// extracts the phone number and command, and processes it accordingly.
+void SmsReceivedCallback(SMS_Encode_Type_t encodeType,
+                         const char* headerStr,
+                         const char* contentStr,
+                         uint32_t    contentLen);
+                         
 // Forward declaration for sending location SMS
 void SendLocationSms(const char* phoneNumber);
 

--- a/app/src/system.c
+++ b/app/src/system.c
@@ -9,14 +9,13 @@
 #include "gps_parse.h"
 
 #include "system.h"
+#include "utils.h"
 #include "network.h"
 #include "led_handler.h"
 #include "gps_tracker.h"
 #include "sms_service.h"
 #include "config_store.h"
 #include "config_commands.h"
-#include "minmea.h"
-#include "utils.h"
 #include "debug.h"
 
 #define MODULE_TAG "System"

--- a/app/src/system.c
+++ b/app/src/system.c
@@ -58,7 +58,7 @@ static void EventHandler(API_Event_t* pEvent)
             LOGE("network detached");
             break;
         case API_EVENT_ID_SIGNAL_QUALITY:
-            g_RSSI = csq_to_percent(pEvent->param1);
+            NetworkSigQualityCallback(pEvent->param1);
             break;
         case API_EVENT_ID_NETWORK_CELL_INFO:
             NetworkCellInfoCallback((Network_Location_t*)pEvent->pParam1, pEvent->param1);

--- a/app/src/system.c
+++ b/app/src/system.c
@@ -68,11 +68,15 @@ static void EventHandler(API_Event_t* pEvent)
             INITIALIZED_ON();
             break;
         case API_EVENT_ID_SMS_RECEIVED:
-            HandleSmsReceived(pEvent);
+            SmsReceivedCallback(
+                (SMS_Encode_Type_t)pEvent->param1,
+                (const char*) pEvent->pParam1,
+                (const char*)pEvent->pParam2,
+                (uint32_t)pEvent->param2);
             break;
         case API_EVENT_ID_SMS_LIST_MESSAGE: {
             SMS_Message_Info_t* msg = (SMS_Message_Info_t*)pEvent->pParam1;
-            HandleSmsListEvent(msg);
+            SmsListMessageCallback(msg);
             break;
         }
         case API_EVENT_ID_GPS_UART_RECEIVED:
@@ -119,7 +123,7 @@ void app_MainTask(void *pData)
     ConfigStore_Init();
     FsInfoTest();    
     gps_Init();
-    SMSInit();
+    SmsInit();
 
     trackerTaskHandle = OS_CreateTask(
         gps_TrackerTask, NULL, NULL,

--- a/app/src/utils.c
+++ b/app/src/utils.c
@@ -2,9 +2,8 @@
 #include <api_fs.h>
 #include <api_inc_time.h>
 
-#include "config_store.h"
-#include "minmea.h"
 #include "utils.h"
+#include "config_store.h"
 #include "debug.h"
 
 int is_leap_year(int year) {

--- a/app/src/utils.h
+++ b/app/src/utils.h
@@ -1,6 +1,30 @@
 #ifndef UTILS_H
 #define UTILS_H
 
+#include "minmea.h"
+
+// Protocol
+typedef enum {
+    PROT_HTTP = 0,
+    PROT_HTTPS
+} t_protocol;
+
+// Log levels
+typedef enum {
+    LOG_LEVEL_NONE = 0,
+    LOG_LEVEL_ERROR,
+    LOG_LEVEL_WARN,
+    LOG_LEVEL_INFO,
+    LOG_LEVEL_DEBUG
+} t_logLevel;
+
+// Log output
+typedef enum {
+    LOGGER_OUTPUT_UART = 0,
+    LOGGER_OUTPUT_TRACE,
+    LOGGER_OUTPUT_FILE
+} t_logOutput;
+
 /**
  * @brief Test function for file system information.
  *

--- a/demo/sms/src/demo_sms.c
+++ b/demo/sms/src/demo_sms.c
@@ -29,7 +29,7 @@ const uint8_t utf8Msg[]    = "utf-8测试短信";//Cause the encoding format of 
 static HANDLE mainTaskHandle = NULL;
 static uint8_t flag = 0;
 
-void SMSInit()
+void SmsInit()
 {
     if(!SMS_SetFormat(SMS_FORMAT_TEXT,SIM0))
     {
@@ -69,7 +69,7 @@ void UartInit()
 void Init()
 {
     UartInit();
-    SMSInit();
+    SmsInit();
 }
 
 


### PR DESCRIPTION
Introduce utils.h to centralize protocol and logging enums and common includes
Rename SMS functions (SMSInit → SmsInit, HandleSmsReceived → SmsReceivedCallback, etc.) and update call sites
Extend network module with NetworkSigQualityCallback, structured cell‐info storage, and printing APIs
Change HTTP POST headers to use Keep-Alive and adjust body CRLF handling